### PR TITLE
Cache

### DIFF
--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -1,0 +1,73 @@
+name: CI (caching)
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  srpm:
+    name: Build srpm
+    runs-on: ubuntu-latest
+    container: fedora:39
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          dnf install -y rpmdevtools
+          mkdir -p /tmp/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
+          rpmbuild -bs -D "_topdir /tmp/rpmbuild" simple.spec
+        working-directory: test/simple
+      - uses: actions/upload-artifact@v3
+        with:
+          name: srpm-artifacts
+          path: |
+            /tmp/rpmbuild/SRPMS/*
+
+  rpm:
+    needs: [ srpm ]
+    name: Build rpm with mock-rpm action
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v3
+        with:
+          name: srpm-artifacts
+      - name: build rpm 1
+        uses: ./
+        with:
+          chroot: fedora-39-x86_64
+          srpm: simple-*.src.rpm
+          cache: true
+      - name: build rpm 2
+        uses: ./
+        with:
+          chroot: fedora-39-x86_64
+          srpm: simple-*.src.rpm
+          cache: true
+      - name: build rpm 3
+        uses: ./
+        with:
+          chroot: fedora-39-x86_64
+          srpm: simple-*.src.rpm
+          cache: true
+      - uses: actions/upload-artifact@v3
+        with:
+          name: rpm-artifacts
+          path: |
+            *.x86_64.rpm
+
+  it:
+    needs: [ rpm ]
+    name: Integration test rpm
+    runs-on: ubuntu-latest
+    container: fedora:39
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: rpm-artifacts
+      - run: dnf install -y simple-*.rpm
+      - name: Test
+        run: simple

--- a/.github/workflows/caching2.yml
+++ b/.github/workflows/caching2.yml
@@ -1,8 +1,8 @@
-name: CI (simple)
+name: CI (srpm action)
 
 on:
   push:
-    branches: [master]
+    branches: [ master ]
   pull_request:
 
 permissions:
@@ -15,11 +15,13 @@ jobs:
     container: fedora:39
     steps:
       - uses: actions/checkout@v4
-      - run: |
-          dnf install -y rpmdevtools
-          mkdir -p /tmp/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
-          rpmbuild -bs -D "_topdir /tmp/rpmbuild" simple.spec
-        working-directory: test/simple
+      - name: bust cache
+        run: date | xargs -I{} echo "# {}" >> test/simple/simple.spec
+      - uses: jw3/mock-srpm@prepv1
+        with:
+          chroot: fedora-39-x86_64
+          spec: test/simple/simple.spec
+          cache: 'true'
       - uses: actions/upload-artifact@v3
         with:
           name: srpm-artifacts
@@ -35,25 +37,26 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: srpm-artifacts
-      - uses: ./
+      - name: build rpm 1
+        uses: ./
         with:
           chroot: fedora-39-x86_64
           srpm: simple-*.src.rpm
+          cache: true
+      - name: build rpm 2
+        uses: ./
+        with:
+          chroot: fedora-39-x86_64
+          srpm: simple-*.src.rpm
+          cache: true
+      - name: build rpm 3
+        uses: ./
+        with:
+          chroot: fedora-39-x86_64
+          srpm: simple-*.src.rpm
+          cache: true
       - uses: actions/upload-artifact@v3
         with:
           name: rpm-artifacts
           path: |
             *.x86_64.rpm
-
-  it:
-    needs: [ rpm ]
-    name: Integration test rpm
-    runs-on: ubuntu-latest
-    container: fedora:39
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: rpm-artifacts
-      - run: dnf install -y simple-*.rpm
-      - name: Test
-        run: simple

--- a/.github/workflows/caching2.yml
+++ b/.github/workflows/caching2.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           name: srpm-artifacts
           path: |
-            /tmp/rpmbuild/SRPMS/*
+            *.src.rpm
 
   rpm:
     needs: [ srpm ]

--- a/.github/workflows/caching2.yml
+++ b/.github/workflows/caching2.yml
@@ -12,7 +12,6 @@ jobs:
   srpm:
     name: Build srpm
     runs-on: ubuntu-latest
-    container: fedora:39
     steps:
       - uses: actions/checkout@v4
       - name: bust cache

--- a/README.md
+++ b/README.md
@@ -28,15 +28,22 @@ jobs:
 
 ## Inputs
 
-| Name           | Required | Default | Description                                                                                                     |
-|----------------|----------|---------|-----------------------------------------------------------------------------------------------------------------|
-| **chroot**     | Y        |         | Mock chroot id ([_list_](https://github.com/rpm-software-management/mock/tree/main/mock-core-configs/etc/mock)) |
-| **srpm**       | Y        |         | Path to the src rpm                                                                                             |
-| **result-dir** | Y        | .       | Path to write rpmbuild outputs                                                                                  |
-| debug          | N        | true    | Show rpmbuild logs on success (auto on-fail)                                                                    |
+| Name           | Required | Default         | Description                                                                                                     |
+|----------------|----------|-----------------|-----------------------------------------------------------------------------------------------------------------|
+| **chroot**     | Y        |                 | Mock chroot id ([_list_](https://github.com/rpm-software-management/mock/tree/main/mock-core-configs/etc/mock)) |
+| **srpm**       | Y        |                 | Path to the src rpm                                                                                             |
+| **cache**      | N        |                 | Enable chroot environment caching                                                                               |
+| **image**      | N        | 'fedora:latest' | Container image for Mock execution                                                                              |
+| **result-dir** | Y        | .               | Path to write rpmbuild outputs                                                                                  |
+| debug          | N        | true            | Show rpmbuild logs on success (auto on-fail)                                                                    |
 
+## Caching
 
+Using actions/cache to persit the Mock chroot, via the `root_cache` plugin, is enabled by default.
 
+Also cached is the container image, but only when mock has been installed by this action.
+
+To enable caching set the `cache` property to 'true'
 
 ## About Mock
 

--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ jobs:
 
 ## Inputs
 
-| Name           | Required | Default         | Description                                                                                                     |
-|----------------|----------|-----------------|-----------------------------------------------------------------------------------------------------------------|
-| **chroot**     | Y        |                 | Mock chroot id ([_list_](https://github.com/rpm-software-management/mock/tree/main/mock-core-configs/etc/mock)) |
-| **srpm**       | Y        |                 | Path to the src rpm                                                                                             |
-| **cache**      | N        |                 | Enable chroot environment caching                                                                               |
-| **image**      | N        | 'fedora:latest' | Container image for Mock execution                                                                              |
-| **result-dir** | Y        | .               | Path to write rpmbuild outputs                                                                                  |
-| debug          | N        | true            | Show rpmbuild logs on success (auto on-fail)                                                                    |
+| Name           | Required | Default            | Description                                                                                                     |
+|----------------|----------|--------------------|-----------------------------------------------------------------------------------------------------------------|
+| **chroot**     | Y        |                    | Mock chroot id ([_list_](https://github.com/rpm-software-management/mock/tree/main/mock-core-configs/etc/mock)) |
+| **srpm**       | Y        |                    | Path to the src rpm                                                                                             |
+| **cache**      | N        |                    | Enable chroot environment caching                                                                               |
+| **image**      | N        | `fedora:latest`    | Container image for Mock execution                                                                              |
+| **debug**      | N        |                    | Show rpmbuild logs on success (auto on-fail)                                                                    |
+| **result-dir** | Y        | `github.workspace` | Target path for writing build artifacts                                                                         |
 
 ## Caching
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@ jobs:
           srpm: simple-*.src.rpm
 ```
 
+## Inputs
+
+| Name           | Required | Default | Description                                                                                                     |
+|----------------|----------|---------|-----------------------------------------------------------------------------------------------------------------|
+| **chroot**     | Y        |         | Mock chroot id ([_list_](https://github.com/rpm-software-management/mock/tree/main/mock-core-configs/etc/mock)) |
+| **srpm**       | Y        |         | Path to the src rpm                                                                                             |
+| **result-dir** | Y        | .       | Path to write rpmbuild outputs                                                                                  |
+| debug          | N        | true    | Show rpmbuild logs on success (auto on-fail)                                                                    |
+
+
+
+
 ## About Mock
 
 Mock is used by the Fedora Build system to populate a chroot environment, which is then used in building a source-RPM (SRPM). It can be used for long-term management of a chroot environment, but generally a chroot is populated (using DNF), an SRPM is built in the chroot to generate binary RPMs, and the chroot is then discarded.

--- a/action.yml
+++ b/action.yml
@@ -45,20 +45,20 @@ runs:
       uses: actions/cache/restore@v3
       with:
         path: /tmp/cache/mock
-        key: chroot-${{ inputs.chroot }}-${{ hashFiles(inputs.spec) }}
+        key: chroot-${{ inputs.chroot }}-${{ hashFiles(inputs.srpm) }}
 
     - id: restore-image
       if: inputs.cache == 'true'
       uses: actions/cache/restore@v3
       with:
         path: /tmp/cache/image.tar.gz
-        key: image-${{ hashFiles(inputs.spec) }}-${{ inputs.image }}
+        key: image-${{ hashFiles(inputs.srpm) }}-${{ inputs.image }}
 
     - id: load-image
       if: inputs.cache == 'true' && steps.restore-image.outputs.cache-hit == 'true'
       run: |
         podman load --input /tmp/cache/image.tar.gz
-        echo "${{ hashFiles(inputs.spec) }}-${{ inputs.image }}" > action.iid
+        echo "${{ hashFiles(inputs.srpm) }}-${{ inputs.image }}" > action.iid
       shell: bash
 
     - id: create-container
@@ -81,7 +81,7 @@ runs:
       if: inputs.cache == 'true' && steps.install-mock.outputs.completed == 'true'
       run: |
         cid=$(cat action.cid)
-        iid="${{ hashFiles(inputs.spec) }}-${{ inputs.image }}"
+        iid="${{ hashFiles(inputs.srpm) }}-${{ inputs.image }}"
         podman commit $cid $iid
         mkdir -p /tmp/mock
         podman save $iid | gzip > /tmp/cache/image.tar.gz

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,13 @@ inputs:
   srpm:
     description: Path to the src rpm
     required: true
+  cache:
+    description: Enable chroot environment caching
+    required: false
+  image:
+    description: Container image for Mock execution
+    required: true
+    default: 'fedora:latest'
   result-dir:
     description: Path to write rpmbuild outputs
     required: true
@@ -33,32 +40,66 @@ runs:
         mkdir -p /tmp/cache/mock
       shell: bash
 
-    - id: restore-mock-cache
+    - id: restore-chroot
       if: inputs.cache == 'true'
       uses: actions/cache/restore@v3
       with:
         path: /tmp/cache/mock
-        key: ${{ inputs.chroot }}-mock-${{ hashFiles(inputs.spec) }}
+        key: chroot-${{ inputs.chroot }}-${{ hashFiles(inputs.spec) }}
+
+    - id: restore-image
+      if: inputs.cache == 'true'
+      uses: actions/cache/restore@v3
+      with:
+        path: /tmp/cache/image.tar.gz
+        key: image-${{ hashFiles(inputs.spec) }}-${{ inputs.image }}
+
+    - id: load-image
+      if: inputs.cache == 'true' && steps.restore-image.outputs.cache-hit == 'true'
+      run: |
+        podman load --input /tmp/cache/image.tar.gz
+        echo "${{ hashFiles(inputs.spec) }}-${{ inputs.image }}" > action.iid
+      shell: bash
 
     - id: create-container
       run: |
-        mkdir -p ${{ inputs.result-dir }}
-        podman run -dt --privileged -v ${{ inputs.result-dir }}:/out -v /tmp/cache/mock:/var/cache/mock fedora:latest > action.cid
+        iid=$(cat action.iid || echo "${{ inputs.image }}")
+        podman run -dt --privileged -v ${{ inputs.result-dir }}:/out -v /tmp/cache/mock:/var/cache/mock $iid > action.cid
       shell: bash
 
-    - id: init-mock-env
+    - id: install-mock
       run: |
         cid=$(cat action.cid)
-        podman exec $cid dnf install -y mock
-        podman exec $cid mock -r ${{ inputs.chroot }} --init
+        mockver=$(podman exec $cid mock --version || true)
+        if [[ -z $mockver ]]; then
+          podman exec $cid dnf install -y mock
+          echo "completed=true" >> $GITHUB_OUTPUT
+        fi
       shell: bash
 
-    - id: cache-bootstrap-on-fail
-      if: inputs.cache == 'true' && failure()
+    - id: save-container
+      if: inputs.cache == 'true' && steps.install-mock.outputs.completed == 'true'
+      run: |
+        cid=$(cat action.cid)
+        iid="${{ hashFiles(inputs.spec) }}-${{ inputs.image }}"
+        podman commit $cid $iid
+        mkdir -p /tmp/mock
+        podman save $iid | gzip > /tmp/cache/image.tar.gz
+      shell: bash
+
+    - id: save-image
+      if: inputs.cache == 'true' && steps.restore-image.outputs.cache-hit != 'true'
       uses: actions/cache/save@v3
       with:
-        path: /tmp/cache/mock
-        key: ${{ steps.restore-mock-cache.outputs.cache-primary-key }}
+        path: /tmp/cache/image.tar.gz
+        key: ${{ steps.restore-image.outputs.cache-primary-key }}
+
+    - id: init-mock
+      if: inputs.cache != 'true' || steps.restore-chroot.outputs.cache-hit != 'true'
+      run: |
+        cid=$(cat action.cid)
+        podman exec $cid mock -r ${{ inputs.chroot }} --init
+      shell: bash
 
     - id: copy-in-srpm
       run: |
@@ -81,9 +122,9 @@ runs:
         cat ${{ inputs.result-dir }}/build.log
       shell: bash
 
-    - id: save-cache
-      if: inputs.cache == 'true' && always()
+    - id: save-chroot
+      if: inputs.cache == 'true' && steps.restore-chroot.outputs.cache-hit != 'true'
       uses: actions/cache/save@v3
       with:
         path: /tmp/cache/mock
-        key: ${{ steps.restore-mock-cache.outputs.cache-primary-key }}
+        key: ${{ steps.restore-chroot.outputs.cache-primary-key }}

--- a/action.yml
+++ b/action.yml
@@ -33,12 +33,12 @@ runs:
         mkdir -p /tmp/cache/mock
       shell: bash
 
-    - id: restore-bootstrap-cache
+    - id: restore-mock-cache
       if: inputs.cache == 'true'
       uses: actions/cache/restore@v3
       with:
-        path: /tmp/cache/mock/${{ inputs.chroot }}-bootstrap
-        key: ${{ inputs.chroot }}-bootstrap-${{ hashFiles(inputs.spec) }}
+        path: /tmp/cache/mock
+        key: ${{ inputs.chroot }}-mock-${{ hashFiles(inputs.spec) }}
 
     - id: create-container
       run: |
@@ -53,12 +53,12 @@ runs:
         podman exec $cid mock -r ${{ inputs.chroot }} --init
       shell: bash
 
-    - id: cache-chroot-bootstrap
-      if: inputs.cache == 'true' && steps.restore-bootstrap-cache.outputs.cache-hit != 'true'
+    - id: cache-bootstrap-on-fail
+      if: inputs.cache == 'true' && failure()
       uses: actions/cache/save@v3
       with:
-        path: /tmp/cache/mock/${{ inputs.chroot }}-bootstrap
-        key: ${{ steps.restore-bootstrap-cache.outputs.cache-primary-key }}
+        path: /tmp/cache/mock
+        key: ${{ steps.restore-mock-cache.outputs.cache-primary-key }}
 
     - id: copy-in-srpm
       run: |
@@ -66,13 +66,6 @@ runs:
         srpm=$(basename ${{ inputs.srpm }})
         podman cp ${{ inputs.srpm }} $cid:/tmp/$srpm
       shell: bash
-
-    - id: restore-chroot-cache
-      if: inputs.cache == 'true'
-      uses: actions/cache/restore@v3
-      with:
-        path: /tmp/cache/mock/${{ inputs.chroot }}
-        key: ${{ inputs.chroot }}-${{ hashFiles(inputs.spec) }}
 
     - id: build
       run: |
@@ -89,8 +82,8 @@ runs:
       shell: bash
 
     - id: save-cache
-      if: inputs.cache == 'true' && steps.restore-chroot-cache.outputs.cache-hit != 'true'
+      if: inputs.cache == 'true' && always()
       uses: actions/cache/save@v3
       with:
-        path: /tmp/cache/mock/${{ inputs.chroot }}
-        key: ${{ steps.restore-chroot-cache.outputs.cache-primary-key }}
+        path: /tmp/cache/mock
+        key: ${{ steps.restore-mock-cache.outputs.cache-primary-key }}

--- a/action.yml
+++ b/action.yml
@@ -27,10 +27,23 @@ runs:
       run: sudo apt install -y podman
       shell: bash
 
+    - id: prep-fs
+      run: |
+        mkdir -p ${{ inputs.result-dir }}
+        mkdir -p /tmp/cache/mock
+      shell: bash
+
+    - id: restore-bootstrap-cache
+      if: inputs.cache == 'true'
+      uses: actions/cache/restore@v3
+      with:
+        path: /tmp/cache/mock/${{ inputs.chroot }}-bootstrap
+        key: ${{ inputs.chroot }}-bootstrap-${{ hashFiles(inputs.spec) }}
+
     - id: create-container
       run: |
         mkdir -p ${{ inputs.result-dir }}
-        podman run -dt --privileged -v ${{ inputs.result-dir }}:/out fedora:latest > action.cid
+        podman run -dt --privileged -v ${{ inputs.result-dir }}:/out -v /tmp/cache/mock:/var/cache/mock fedora:latest > action.cid
       shell: bash
 
     - id: init-mock-env
@@ -40,11 +53,31 @@ runs:
         podman exec $cid mock -r ${{ inputs.chroot }} --init
       shell: bash
 
-    - id: build
+    - id: cache-chroot-bootstrap
+      if: inputs.cache == 'true' && steps.restore-bootstrap-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v3
+      with:
+        path: /tmp/cache/mock/${{ inputs.chroot }}-bootstrap
+        key: ${{ steps.restore-bootstrap-cache.outputs.cache-primary-key }}
+
+    - id: copy-in-srpm
       run: |
         cid=$(cat action.cid)
         srpm=$(basename ${{ inputs.srpm }})
         podman cp ${{ inputs.srpm }} $cid:/tmp/$srpm
+      shell: bash
+
+    - id: restore-chroot-cache
+      if: inputs.cache == 'true'
+      uses: actions/cache/restore@v3
+      with:
+        path: /tmp/cache/mock/${{ inputs.chroot }}
+        key: ${{ inputs.chroot }}-${{ hashFiles(inputs.spec) }}
+
+    - id: build
+      run: |
+        cid=$(cat action.cid)
+        srpm=$(basename ${{ inputs.srpm }})
         podman exec $cid mock -r ${{ inputs.chroot }} rebuild /tmp/$srpm --resultdir /out
       shell: bash
 
@@ -54,3 +87,10 @@ runs:
         ls -R ${{ inputs.result-dir }}
         cat ${{ inputs.result-dir }}/build.log
       shell: bash
+
+    - id: save-cache
+      if: inputs.cache == 'true' && steps.restore-chroot-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v3
+      with:
+        path: /tmp/cache/mock/${{ inputs.chroot }}
+        key: ${{ steps.restore-chroot-cache.outputs.cache-primary-key }}


### PR DESCRIPTION
Adds optional caching for the mock package install and the mock chroot.

When the `cache` property is set to 'true' this action may cache both the mock container image and the initialized chroot environment. The caching implementation is opinionated about how and when these get cached.

This commit also weaves in custom image support through the 'image' property. When caching while using a custom image, the image will only be cached if mock was not preloaded in the custom image. If mock was preloaded, the image will not be cached, which will result in a slightly faster execution.

The cache key is based off of a hash of the spec file provided to the action. So when the spec file is edited, the cache will be invalidated.

The cache key is calculated in the same way as the mock-srpm action, which allows for cache sharing when using these actions together.

Closes #3
Closes #4